### PR TITLE
support 'latest' as version

### DIFF
--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -1,6 +1,8 @@
 ---
-# Package states: installed or latest
-intellij_pkg_state: installed
 intellij_tmp: /tmp/ideaIC-{{intellij_version}}.tar.gz
 intellij_install_dir: /opt/intellij
-intellij_version: 14.1.4
+
+# intellij_version can be either 'latest', or a specific version (e.g. '14.1.4' or '2016.2.4' )
+intellij_version: latest
+
+

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -6,6 +6,21 @@
     - unzip
   tags: ["packages","intellij"]
 
+- name: Find latest version
+  uri:
+    url: "https://data.services.jetbrains.com/products/releases?code=IIU%2CIIC&latest=true&type=release"
+    return_content: yes
+    validate_certs: no
+    body_format: json
+  register: intellij_releases_response
+  when: intellij_version == 'latest'
+  tags: ["packages","intellij"]
+
+- set_fact:
+    intellij_version: "{{ intellij_releases_response.json.IIC.0.version }}"
+  when: intellij_version == 'latest'
+  tags: ["packages","intellij"]
+
 - name: Download intellij
   get_url: url={{intellij_url}} dest={{intellij_tmp}}
   tags: ["packages","intellij"]


### PR DESCRIPTION
- supports `intellij_version: latest` 
- installing latest version is the default.
- intellij_pkg_state variable was removed as unused.

This PR only extracts the version information from the json quoted below. More could be done with that json (e.g. support ultimate edition)

``` json
{
            "IIC": [
                {
                    "build": "162.2032", 
                    "date": "2016-09-09", 
                    "downloads": {
                        "linux": {
                            "checksumLink": "https://download.jetbrains.com/idea/ideaIC-2016.2.4.tar.gz.sha256", 
                            "link": "https://download.jetbrains.com/idea/ideaIC-2016.2.4.tar.gz", 
                            "size": 336281885
                        }, 
                        "mac": {
                            "checksumLink": "https://download.jetbrains.com/idea/ideaIC-2016.2.4.dmg.sha256", 
                            "link": "https://download.jetbrains.com/idea/ideaIC-2016.2.4.dmg", 
                            "size": 329442092
                        }, 
                        "windows": {
                            "checksumLink": "https://download.jetbrains.com/idea/ideaIC-2016.2.4.exe.sha256", 
                            "link": "https://download.jetbrains.com/idea/ideaIC-2016.2.4.exe", 
                            "size": 290335080
                        }
                    }, 
                    "majorVersion": "2016.2", 
                    "type": "release", 
                    "version": "2016.2.4"
                }
            ], 
            "IIU": [
                {
                    "build": "162.2032", 
                    "date": "2016-09-09", 
                    "downloads": {
                        "linux": {
                            "checksumLink": "https://download.jetbrains.com/idea/ideaIU-2016.2.4.tar.gz.sha256", 
                            "link": "https://download.jetbrains.com/idea/ideaIU-2016.2.4.tar.gz", 
                            "size": 506828925
                        }, 
                        "mac": {
                            "checksumLink": "https://download.jetbrains.com/idea/ideaIU-2016.2.4.dmg.sha256", 
                            "link": "https://download.jetbrains.com/idea/ideaIU-2016.2.4.dmg", 
                            "size": 494351393
                        }, 
                        "windows": {
                            "checksumLink": "https://download.jetbrains.com/idea/ideaIU-2016.2.4.exe.sha256", 
                            "link": "https://download.jetbrains.com/idea/ideaIU-2016.2.4.exe", 
                            "size": 439776840
                        }
                    }, 
                    "majorVersion": "2016.2", 
                    "type": "release", 
                    "version": "2016.2.4"
                }
            ]
        }
```
